### PR TITLE
Add Github Action to deploy branch previews to GOV.UK PaaS

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -1,0 +1,54 @@
+name: Delete deployment
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every weekday at 10am
+    - cron: '0 10 * * 1-5'
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  delete-deployment:
+    name: Delete prototype preview
+    runs-on: ubuntu-latest
+    environment: preview
+    steps:
+      - name: Install Cloud Foundry client
+        env:
+          CF_CLI_DOWNLOAD_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v7
+        run: |
+          curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
+          cf version
+      - name: PaaS login
+        env:
+          CF_API_URL: https://api.london.cloud.service.gov.uk
+          CF_ORG_NAME: gds-digital-identity-accounts
+          CF_SPACE_NAME: sandbox
+          CF_USERNAME: ${{ secrets.cf_username }}
+          CF_PASSWORD: ${{ secrets.cf_password }}
+        run: |
+          cf api ${CF_API_URL}
+          cf auth
+          cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
+      - name: Delete app
+        if: ${{ github.event_name != 'schedule' }}
+        run: |
+          branch_name=$([[ ${{ github.event_name }} == 'pull_request' ]] && echo ${{ github.head_ref }} || echo ${{ github.ref_name }})
+          app_name=$(echo prototype-preview-${branch_name} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
+          cf delete $app_name -rf
+      - name: Clean up stale deployments
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          cut_off_date=$(date -d "30 days ago" +%Y-%m-%d)
+          echo "Cut off date: $cut_off_date"
+
+          for app in $(cf apps | awk 'NR>3 {print $1}')
+          do
+            last_upload_date=$(cf events $app | grep audit.app.package.upload | awk 'NR==1 {print $1}')
+            echo "$app | last uploaded: $last_upload_date"
+
+            if [[ -z $last_upload_date || $(date -d $last_upload_date +%Y-%m-%d) < $cut_off_date ]]; then
+              cf delete $app -rf
+            fi
+          done

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,18 @@
+name: Deploy branch preview
+
+on: pull_request
+
+jobs:
+  deploy-preview:
+    name: Preview
+    uses: alphagov/govuk-accounts-explore-prototype-1/.github/workflows/deploy-to-paas.yml@a6dca9ed279abf73085c72de838c4845be4b34e7
+    with:
+      environment: preview
+      cf_space_name: sandbox
+      app_name: prototype-preview-${{ github.head_ref }}
+    secrets:
+      cf_username: ${{ secrets.CF_USERNAME }}
+      cf_password: ${{ secrets.CF_PASSWORD }}
+      username: ${{ secrets.USERNAME }}
+      password: ${{ secrets.PASSWORD }}
+      notify_api_key: ${{ secrets.NOTIFY_API_KEY }}

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -1,0 +1,74 @@
+name: Deploy to PaaS
+
+on:
+  workflow_call:
+    inputs:
+      cf_space_name: { required: true, type: string }
+      app_name: { required: true, type: string }
+      environment: { required: true, type: string }
+      url: { required: false, type: string }
+      instances: { required: false, type: number, default: 1 }
+      rolling_deployment: { required: false, type: boolean, default: false }
+    secrets:
+      cf_username: { required: true }
+      cf_password: { required: true }
+      username: { required: true }
+      password: { required: true }
+      notify_api_key: { required: true }
+    outputs:
+      deployment_url:
+        description: "The PaaS deployment URL"
+        value: ${{ jobs.deploy.outputs.deployment_url }}
+
+jobs:
+  deploy:
+    name: Deploy to PaaS
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.set_deployment_url.outputs.deployment_url }}
+    outputs:
+      deployment_url: ${{ steps.set_deployment_url.outputs.deployment_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Cloud Foundry client
+        env:
+          CF_CLI_DOWNLOAD_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v7
+        run: |
+          curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
+          cf version
+      - name: Set deployment hostname
+        id: set_deployment_hostname
+        if: ${{ inputs.app_name != null }}
+        run: |
+          # Downcase the hostname and limit length to 63 characters as per PaaS requirements
+          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
+          echo "::set-output name=hostname::${hostname}"
+      - name: Set deployment URL
+        id: set_deployment_url
+        run: |
+          url=${{ inputs.url }}
+          hostname=${{ steps.set_deployment_hostname.outputs.hostname }}
+          deployment_url=$([[ $url ]] && echo $url || echo "https://${hostname}.london.cloudapps.digital")
+          echo "::set-output name=deployment_url::${deployment_url}"
+      - name: PaaS login
+        env:
+          CF_API_URL: https://api.london.cloud.service.gov.uk
+          CF_ORG_NAME: gds-digital-identity-accounts
+          CF_SPACE_NAME: ${{ inputs.cf_space_name }}
+          CF_USERNAME: ${{ secrets.cf_username }}
+          CF_PASSWORD: ${{ secrets.cf_password }}
+        run: |
+          cf api ${CF_API_URL}
+          cf auth
+          cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
+      - name: Push to PaaS
+        env:
+          ROLLING_DEPLOYMENT: ${{ inputs.rolling_deployment }}
+        run: |
+          cf push ${{ steps.set_deployment_hostname.outputs.hostname }} \
+            --var username=${{ secrets.username }} \
+            --var password=${{ secrets.password }} \
+            --var notify-api-key=${{ secrets.password }} \
+            --instances ${{ inputs.instances }} $([[ $ROLLING_DEPLOYMENT == "true" ]] && echo --strategy rolling)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ To run the application locally you will need to include API_URL environment vari
 
 `API_URL=http://localhost:3050 npm start`
 
+## Deploys to GOV.UK PaaS
+
+This repository has Github Actions which deploy pull request preview apps to GOV.UK Paas
+whenever a pull request is opened or updated. This allows people working on designs to 
+easily share early protoypes within the team.
+
+The preview apps are deleted once the pull request is merged or closed, or after 30 days 
+if nothing has changed.
+
+### Updating credentials for deployed apps
+
+The username and password for deployed apps are set by secrets saved in this repository.
+To update them, go to [the secrets setting page](https://github.com/alphagov/govuk-accounts-explore-prototype-1/settings/secrets/actions) 
+and update the values for `USERNAME` and `PASSWORD`.
+
+You'll then need to reload the app so it can pick up the new values. You can do this either 
+by pushing a new commit to the branch or finding the most recent deploy action in 
+[the list of completed actions](https://github.com/alphagov/govuk-accounts-explore-prototype-1/actions/workflows/deploy-preview.yml) 
+and clicking 'Re-run all jobs'.
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+  - name: govuk-accounts-explore-prototype
+    memory: 256M
+    disk_quota: 512M
+    command: npm start
+    buildpacks:
+    - nodejs_buildpack
+    env:
+      NOTIFYAPIKEY: ((notify-api-key))
+      API_URL: https://www.gov.uk/api/content
+      USERNAME: ((username))
+      PASSWORD: ((password))


### PR DESCRIPTION
This repo is currently linked to and deployed on GOV.UK's Heroku account
however the team that manages it has moved programmes within GDS and
will soon lose access to the shared Heroku account.

Deploying previews to PaaS instead via Github actions will mean that the
config and secrets for previews is all managed within the repo, which
will be easier to maintain in the future.

Trigger the deploy workflow when a PR is created or updated
so people working on this repo can see and share their changes while
still working on them.

Also add a delete workflow which is triggered in two ways. 

Firstly, it runs when a PR is closed or merged. In that case it 
looks in PaaS for an app with the name expected for the 
branch name, and deletes it.

It also runs on a schedule at 10am every day and deletes any deployed
apps that are older than 30 days. We'll have to update this behaviour
slightly so that it doesn't delete any 'production' prototypes that we
want to keep running for longer than that.

---
[Trello](https://trello.com/c/KLe2QxMS/1337-deploy-prototypes-to-govuk-paas)