### PR TITLE
Add action to deploy a long-lived prototype on release

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -45,7 +45,7 @@ jobs:
 
           for app in $(cf apps | awk 'NR>3 {print $1}')
           do
-            last_upload_date=$(cf events $app | grep audit.app.package.upload | awk 'NR==1 {print $1}')
+            last_upload_date=$(cf app $app | grep 'last uploaded:' | cut -d' ' -f 3-)
             echo "$app | last uploaded: $last_upload_date"
 
             if [[ -z $last_upload_date || $(date -d $last_upload_date +%Y-%m-%d) < $cut_off_date ]]; then

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -49,6 +49,8 @@ jobs:
             echo "$app | last uploaded: $last_upload_date"
 
             if [[ -z $last_upload_date || $(date -d $last_upload_date +%Y-%m-%d) < $cut_off_date ]]; then
-              cf delete $app -rf
+              if [[ $app == prototype-preview* ]]; then
+                cf delete $app -rf
+              fi
             fi
           done

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,7 +7,7 @@ jobs:
     name: Preview
     uses: alphagov/govuk-accounts-explore-prototype-1/.github/workflows/deploy-to-paas.yml@a6dca9ed279abf73085c72de838c4845be4b34e7
     with:
-      environment: preview
+      environment: preview-${{ github.head_ref }}
       cf_space_name: sandbox
       app_name: prototype-preview-${{ github.head_ref }}
     secrets:

--- a/.github/workflows/deploy-protoype.yml
+++ b/.github/workflows/deploy-protoype.yml
@@ -1,0 +1,20 @@
+name: Deploy prototype to GOV.UK PaaS
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  deploy-prototype:
+    name: Deploy protoype
+    uses: alphagov/govuk-accounts-explore-prototype-1/.github/workflows/deploy-to-paas.yml@2a748fc078cef0c5cd18e27809058b0d6e297da2
+    with:
+      environment: govuk-accounts-prototype-${{ github.event.release.tag_name }}
+      cf_space_name: sandbox
+      app_name: govuk-accounts-prototype-${{ github.event.release.tag_name }}
+    secrets:
+      cf_username: ${{ secrets.CF_USERNAME }}
+      cf_password: ${{ secrets.CF_PASSWORD }}
+      username: ${{ secrets.USERNAME }}
+      password: ${{ secrets.PASSWORD }}
+      notify_api_key: ${{ secrets.NOTIFY_API_KEY }}

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ inputs.app_name != null }}
         run: |
           # Downcase the hostname and limit length to 63 characters as per PaaS requirements
-          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
+          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr '.' '-' | cut -c1-63)
           echo "::set-output name=hostname::${hostname}"
       - name: Set deployment URL
         id: set_deployment_url


### PR DESCRIPTION
When a new release is created in Github, the action will take the contents of the
`main` branch and deploy it to GOV.UK PaaS as a long lived, stable
prototype for user testing.

Each release prototype gets its own environment named off the release
tag so it won't be overwritten by subsequent deploys.

Change the scheduled job that looks for old deploys to only 
delete branch preview deploys older than 30 days based on
the app name, and also fix a bug which meant it would never 
delete an old deploy (see last commit message for details).

---
[Trello](https://trello.com/c/KLe2QxMS/1337-deploy-prototypes-to-govuk-paas)