### PR TITLE
Set delete environment to the same as deploy

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -12,7 +12,7 @@ jobs:
   delete-deployment:
     name: Delete prototype preview
     runs-on: ubuntu-latest
-    environment: preview
+    environment: preview-${{ github.head_ref }}
     steps:
       - name: Install Cloud Foundry client
         env:


### PR DESCRIPTION
This was missed from #126. We should set the environment the delete
action runs in to be the same as the one it deploys to so the list of
environments in Github stays reasonable.

---
[Trello](https://trello.com/c/KLe2QxMS/1337-deploy-prototypes-to-govuk-paas)