### PR TITLE
Fix step to delete old deployments

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -45,7 +45,7 @@ jobs:
 
           for app in $(cf apps | awk 'NR>3 {print $1}')
           do
-            last_upload_date=$(cf app $app | grep 'last uploaded:' | cut -d' ' -f 3-)
+            last_upload_date="$(cf app $app | grep 'last uploaded:' | cut -d' ' -f 3- | awk ' { t = $2; $2 = $3; $3 = t; print; } ')"
             echo "$app | last uploaded: $last_upload_date"
 
             if [[ -z $last_upload_date || $(date -d $last_upload_date +%Y-%m-%d) < $cut_off_date ]]; then

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -3,8 +3,8 @@ name: Delete deployment
 on:
   workflow_dispatch:
   schedule:
-    # Every weekday at 10am
-    - cron: '0 10 * * 1-5'
+    # Every weekday at 4am
+    - cron: '0 4 * * 1-5'
   pull_request:
     types: [ closed ]
 


### PR DESCRIPTION
This step is meant to filter for all deployments that are older than 30
days and delete any that match the naming convention for branch preview
deploys.

However, the `date` command to parse the date from the output of
`cf app $app` always failed which meant this step was deleting all
branch preview deploys every time it ran.

An example of this failure can be seen at [[1]].

`cf app $app` outputs a date string like `Thu 05 May 16:58:33 BST 2022'`
which isn't a format that `date` can parse. This commit adds an extra
string processing step that switches the position of the day and month
in the string, resulting in something like
`Thu May 05 16:58:33 BST 2022` which `date` can parse.

To verify this is working correctly, you can run the below script which 
replaces the outputs of the Cloud Foundry commands with the 
extracted date string. Note this will need to be run on Ubuntu or 
another Linux OS as the `date` command works differently on Mac.

```bash
for app in prototype-preview-data-management
do
  last_upload_date="$(echo 'Thu 05 May 16:58:33 BST 2022' | awk ' { t = $2; $2 = $3; $3 = t; print; } ')"
  echo "$app | last uploaded: $last_upload_date"

  if [[ -z $last_upload_date || $(date -d "$last_upload_date" +%Y-%m-%d) < $cut_off_date ]]; then
    if [[ $app == prototype-preview* ]]; then
      echo "deleted $app"
    fi
  fi
done
``` 

[1]: https://github.com/alphagov/govuk-accounts-explore-prototype-1/runs/6304209328?check_suite_focus=true